### PR TITLE
#56 [Feat] - 음악 재생

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -71,23 +71,34 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.core:core-ktx:1.12.0'
+    implementation 'androidx.activity:activity-compose:1.8.2'
     implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation 'androidx.compose.material:material:1.5.4'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-    implementation 'com.google.android.material:material:1.11.0'
-    implementation 'androidx.core:core-ktx:1.12.0'
-    implementation 'androidx.navigation:navigation-runtime-ktx:2.7.6'
-    implementation 'androidx.room:room-common:2.6.1'
+
     implementation 'androidx.benchmark:benchmark-common:1.2.3'
-    testImplementation 'junit:junit:4.13.2'
+
+    implementation 'androidx.core:core-ktx:1.12.0'
+
+    implementation 'androidx.compose.animation:animation:1.5.4'
+    implementation 'androidx.compose.material:material:1.5.4'
+    implementation 'androidx.compose.ui:ui-tooling:1.5.4'
+    androidTestImplementation 'androidx.compose.ui:ui-test-junit4:1.5.4'
+
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+
+    implementation 'com.google.android.material:material:1.11.0'
+
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.7.0"
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-compose:2.6.2'
+
+    testImplementation 'junit:junit:4.13.2'
+
 
     // splash
     implementation 'androidx.core:core-splashscreen:1.0.1'
 
     // navigation
     implementation "androidx.navigation:navigation-compose:2.7.6"
+    implementation 'androidx.navigation:navigation-runtime-ktx:2.7.6'
 
     // view Model
     implementation 'androidx.fragment:fragment-ktx:1.6.1'
@@ -112,28 +123,14 @@ dependencies {
     // touch image view TODO: 삭제
     implementation 'com.github.MikeOrtiz:TouchImageView:1.4.1'
 
-    // MARK: compose
-    // Integration with activities
-    implementation 'androidx.activity:activity-compose:1.8.2'
-    // Compose Material Design
-    implementation 'androidx.compose.material:material:1.5.4'
-    // Animations
-    implementation 'androidx.compose.animation:animation:1.5.4'
-    // Tooling support (Previews, etc.)
-    implementation 'androidx.compose.ui:ui-tooling:1.5.4'
-    // Integration with ViewModels
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-compose:2.6.2'
-    // UI Tests
-    androidTestImplementation 'androidx.compose.ui:ui-test-junit4:1.5.4'
-
     implementation "androidx.datastore:datastore-preferences:1.0.0"
     implementation "androidx.constraintlayout:constraintlayout-compose-android:1.1.0-alpha13"
 
     // Room
-    implementation 'androidx.room:room-runtime:2.5.0'
-    implementation 'androidx.core:core-ktx:1.12.0'
-    kapt 'androidx.room:room-compiler:2.5.0'
+    implementation 'androidx.room:room-common:2.6.1'
     implementation 'androidx.room:room-ktx:2.6.1'
+    implementation 'androidx.room:room-runtime:2.5.0'
+    kapt 'androidx.room:room-compiler:2.5.0'
     annotationProcessor "android.arch.persistence.room:compiler:1.1.1"
 
     //Material Icon

--- a/app/src/main/java/com/soi/moya/data/MusicManager.kt
+++ b/app/src/main/java/com/soi/moya/data/MusicManager.kt
@@ -5,7 +5,9 @@ import androidx.lifecycle.LiveData
 import com.soi.moya.models.Music
 import com.soi.moya.util.UiState
 import androidx.lifecycle.MutableLiveData
+import com.soi.moya.models.MusicInfo
 import com.soi.moya.models.Team
+import com.soi.moya.models.toMusicInfo
 import com.soi.moya.repository.FirebaseRepository
 
 class MusicManager private constructor() {
@@ -44,6 +46,21 @@ class MusicManager private constructor() {
         allMusicsLiveData.postValue(flattenedList)
 
         return allMusicsLiveData
+    }
+
+    fun getAllMusicInfo(): MutableLiveData<List<MusicInfo>> {
+        val allMusicInfoLiveData = MutableLiveData<List<MusicInfo>>()
+
+        val flattenedList = _musics.values.flatMap {
+            it.value.orEmpty()
+        }
+        val musicInfoList = flattenedList.map { music ->
+            music.toMusicInfo(Team.valueOf(_musics.entries.first { it.value.value?.contains(music) == true }.key))
+        }
+
+        allMusicInfoLiveData.postValue(musicInfoList)
+
+        return allMusicInfoLiveData
     }
 
     fun getMusicById(songId: String): Music {

--- a/app/src/main/java/com/soi/moya/data/MusicManager.kt
+++ b/app/src/main/java/com/soi/moya/data/MusicManager.kt
@@ -1,5 +1,6 @@
 package com.soi.moya.data
 
+import android.util.Log
 import androidx.lifecycle.LiveData
 import com.soi.moya.models.Music
 import com.soi.moya.util.UiState
@@ -43,6 +44,17 @@ class MusicManager private constructor() {
         allMusicsLiveData.postValue(flattenedList)
 
         return allMusicsLiveData
+    }
+
+    fun getMusicById(songId: String): Music {
+        for ((_, liveData) in _musics) {
+            val musicList = liveData.value ?: continue
+            val music = musicList.find { it.id == songId }
+            if (music != null) {
+                return music
+            }
+        }
+        throw  IllegalArgumentException("Invalid songId: $songId")
     }
 
     companion object {

--- a/app/src/main/java/com/soi/moya/models/Music.kt
+++ b/app/src/main/java/com/soi/moya/models/Music.kt
@@ -9,6 +9,26 @@ data class Music(
     val url: String = ""
 )
 
+data class MusicInfo(
+    val id: String = "",
+    val info: String = "",
+    val lyrics: String = "",
+    val title: String = "",
+    val type: Boolean = false,
+    val team: Team = Team.doosan,
+    val url: String = ""
+)
+
+fun Music.toMusicInfo(team: Team): MusicInfo = MusicInfo(
+    id = id,
+    team = team,
+    title = title,
+    lyrics = lyrics,
+    info = info,
+    type = type,
+    url = url
+)
+
 fun Music.toStoredMusic(team: Team, order: Int, date: String, playlist: String): StoredMusic = StoredMusic(
     id = id,
     team = team.name,

--- a/app/src/main/java/com/soi/moya/models/Team.kt
+++ b/app/src/main/java/com/soi/moya/models/Team.kt
@@ -131,7 +131,7 @@ enum class Team {
             lotte -> "Lotte"
             lg -> "LG"
             ssg -> "SSG"
-            ktWiz -> "KtWiz"
+            ktWiz -> "Kt"
             nc -> "NC"
             kiwoom -> "Kiwoom"
             kia -> "Kia"

--- a/app/src/main/java/com/soi/moya/repository/MusicPlayerManager.kt
+++ b/app/src/main/java/com/soi/moya/repository/MusicPlayerManager.kt
@@ -2,16 +2,22 @@ package com.soi.moya.repository
 
 import android.app.Application
 import android.content.Context
+import android.media.AudioAttributes
 import android.media.MediaPlayer
 import com.soi.moya.R
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import java.io.IOException
 
 class MusicPlayerManager(application: Application) {
     private val _isPlaying = MutableStateFlow(false)
     val isPlaying: StateFlow<Boolean> = _isPlaying
 
-    private val mediaPlayer = MediaPlayer.create(application, R.raw.test)
+    private val mediaPlayer = MediaPlayer().apply {
+        setAudioAttributes(
+            AudioAttributes.Builder().setContentType(AudioAttributes.CONTENT_TYPE_MUSIC).build()
+        )
+    }
 
     fun togglePlayPause() {
         _isPlaying.value = !_isPlaying.value
@@ -58,4 +64,16 @@ class MusicPlayerManager(application: Application) {
         }
     }
 
+    fun playMusicFromUrl(url: String) {
+        try {
+            mediaPlayer.apply {
+                reset()
+                setDataSource(url)
+                prepare()
+                play()
+            }
+        } catch (e: IOException) {
+            e.printStackTrace()
+        }
+    }
 }

--- a/app/src/main/java/com/soi/moya/ui/AppViewModelProvider.kt
+++ b/app/src/main/java/com/soi/moya/ui/AppViewModelProvider.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.soi.moya.ui.listItem_menu.ListItemMenuViewModel
 import com.soi.moya.ui.music_list.MusicListViewModel
+import com.soi.moya.ui.music_player.MusicPlayerViewModel
 import com.soi.moya.ui.music_storage.MusicStorageViewModel
 import com.soi.moya.ui.notice.NoticeBottomSheetViewModel
 import com.soi.moya.ui.search.SearchViewModel

--- a/app/src/main/java/com/soi/moya/ui/UIConsts.kt
+++ b/app/src/main/java/com/soi/moya/ui/UIConsts.kt
@@ -3,5 +3,5 @@ package com.soi.moya.ui
 const val MUSIC_LIST = "MUSIC_LIST"
 const val SEARCH = "SEARCH"
 const val MUSIC_STORAGE = "MUSIC_STORAGE"
-const val MUSIC_PlAYER = "MUSIC_PLAYER/{songId}"
+const val MUSIC_PlAYER = "MUSIC_PLAYER/{team}/{songId}"
 const val SELECT_TEAM = "SELECT_TEAM"

--- a/app/src/main/java/com/soi/moya/ui/bottom_nav/BottomNavScreen.kt
+++ b/app/src/main/java/com/soi/moya/ui/bottom_nav/BottomNavScreen.kt
@@ -199,11 +199,8 @@ fun NavGraph(navController: NavHostController) {
         composable(NavItem.MusicStorage.route) {
             MusicStorageScreen(navController = navController)
         }
-        composable(MUSIC_PlAYER) { backStackEntry ->
-            MusicPlayerScreen(
-                navController = navController,
-                songId = backStackEntry.arguments?.getString("songId")
-            )
+        composable(MUSIC_PlAYER) {
+            MusicPlayerScreen(navController = navController)
         }
         composable(SELECT_TEAM) {
             SelectTeamScreen(

--- a/app/src/main/java/com/soi/moya/ui/component/MusicListItem.kt
+++ b/app/src/main/java/com/soi/moya/ui/component/MusicListItem.kt
@@ -69,7 +69,7 @@ fun MusicInfoView(music: Music, team: Team) {
             .aspectRatio(1f)
             .clip(RoundedCornerShape(8.dp)),
         // TODO: Music 객체로 팀 확인하는 로직 생각해보기
-        painter = painterResource(id = if (music.type) team.getTeamAlbumImageResourceId() else team.getPlayerAlbumImageResourceId()),
+        painter = painterResource(id = if (music.type) team.getPlayerAlbumImageResourceId() else team.getTeamAlbumImageResourceId()),
         contentDescription = null,
     )
     Column(

--- a/app/src/main/java/com/soi/moya/ui/component/MusicListItem.kt
+++ b/app/src/main/java/com/soi/moya/ui/component/MusicListItem.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.soi.moya.R
 import com.soi.moya.models.Music
+import com.soi.moya.models.Team
 import com.soi.moya.ui.theme.MoyaColor
 import com.soi.moya.ui.theme.MoyaFont
 import com.soi.moya.ui.theme.getTextStyle
@@ -29,6 +30,7 @@ import com.soi.moya.ui.theme.getTextStyle
 @Composable
 fun MusicListItem(
     music: Music,
+    team: Team,
     buttonImageResourceId: Int,
     onClickCell: (music: Music) -> Unit,
     onClickExtraButton: (music: Music) -> Unit
@@ -48,7 +50,7 @@ fun MusicListItem(
             Row(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                MusicInfoView(music = music)
+                MusicInfoView(music = music, team = team)
             }
         }
 
@@ -59,7 +61,7 @@ fun MusicListItem(
 }
 
 @Composable
-fun MusicInfoView(music: Music) {
+fun MusicInfoView(music: Music, team: Team) {
     Image(
         contentScale = ContentScale.Crop,
         modifier = Modifier
@@ -67,7 +69,7 @@ fun MusicInfoView(music: Music) {
             .aspectRatio(1f)
             .clip(RoundedCornerShape(8.dp)),
         // TODO: Music 객체로 팀 확인하는 로직 생각해보기
-        painter = painterResource(id = R.drawable.album_doosan),
+        painter = painterResource(id = if (music.type) team.getTeamAlbumImageResourceId() else team.getPlayerAlbumImageResourceId()),
         contentDescription = null,
     )
     Column(
@@ -105,6 +107,7 @@ fun MusicListExtraButton(modifier: Modifier, resourceId: Int, onClick: () -> Uni
 fun MusicListItemPreview() {
     MusicListItem(
         music = Music(title = "Title", info = "SubTitle"),
+        team = Team.doosan,
         onClickCell = {},
         onClickExtraButton = {},
         buttonImageResourceId = R.drawable.ellipse

--- a/app/src/main/java/com/soi/moya/ui/music_list/MusicListScreen.kt
+++ b/app/src/main/java/com/soi/moya/ui/music_list/MusicListScreen.kt
@@ -229,7 +229,7 @@ fun MusicListItemView(music: Music, team: Team, navController: NavHostController
         music = music,
         team = team,
         onClickCell = {
-            navController.navigate("MUSIC_PLAYER/${music.id}")
+            navController.navigate("MUSIC_PLAYER/${team.name}/${music.id}")
         },
         onClickExtraButton = {
             Log.d("clicked", "extra button")

--- a/app/src/main/java/com/soi/moya/ui/music_list/MusicListScreen.kt
+++ b/app/src/main/java/com/soi/moya/ui/music_list/MusicListScreen.kt
@@ -109,6 +109,7 @@ fun MusicListScreen(
                             viewModel.getMusicAt(page = page, index = index)
                             MusicListItemView(
                                 music = viewModel.getMusicAt(page = page, index = index),
+                                team = Team.valueOf(selectedTeam),
                                 navController = navController
                             )
                         }
@@ -219,13 +220,14 @@ fun MusicListHeaderView(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun MusicListItemView(music: Music, navController: NavHostController) {
+fun MusicListItemView(music: Music, team: Team, navController: NavHostController) {
     val sheetState = rememberModalBottomSheetState()
     val scope = rememberCoroutineScope()
     var showBottomSheet by remember { mutableStateOf(false) }
     Divider()
     MusicListItem(
         music = music,
+        team = team,
         onClickCell = {
             navController.navigate("MUSIC_PLAYER/${music.id}")
         },

--- a/app/src/main/java/com/soi/moya/ui/music_list/MusicListViewModel.kt
+++ b/app/src/main/java/com/soi/moya/ui/music_list/MusicListViewModel.kt
@@ -41,8 +41,8 @@ class MusicListViewModel(
 
         val selectedTeam = _selectedTeam.value
         _musicManager.getFilteredSelectedTeamMusic(selectedTeam).observeForever { musics ->
-            _teamMusics.value = musics?.filter { it.type } ?: emptyList()
-            _playerMusics.value = musics?.filter { !it.type } ?: emptyList()
+            _teamMusics.value = musics?.filter { !it.type } ?: emptyList()
+            _playerMusics.value = musics?.filter { it.type } ?: emptyList()
         }
     }
 

--- a/app/src/main/java/com/soi/moya/ui/music_player/MusicPlayerScreen.kt
+++ b/app/src/main/java/com/soi/moya/ui/music_player/MusicPlayerScreen.kt
@@ -24,13 +24,11 @@ import androidx.compose.material.Slider
 import androidx.compose.material.SliderDefaults
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -57,7 +55,7 @@ fun MusicPlayerScreen(
     val duration = viewModel.getDuration()
 
     val progress = remember { mutableFloatStateOf(0f) }
-    val isLike = rememberSaveable { mutableStateOf( true ) }
+    val isLike by viewModel.isLike.collectAsState()
 
     Column(
         modifier = Modifier
@@ -71,12 +69,10 @@ fun MusicPlayerScreen(
             isLike = isLike,
             onClickBackButton = {
                 viewModel.popBackStack(navController = navController)
-            },
-            onClickHeartButton = {
-                viewModel.updateLikeMusic(isLike = it)
-                isLike.value = !it
             }
-        )
+        ) {
+            viewModel.updateLikeMusic()
+        }
 
         MusicLylicView(
             music = viewModel.music,
@@ -106,17 +102,17 @@ fun MusicPlayerScreen(
 fun MusicNavigationBar(
     music: Music,
     team: Team,
-    isLike: MutableState<Boolean>,
+    isLike: Boolean,
     onClickBackButton: () -> Unit,
     onClickHeartButton: (Boolean) -> Unit
 ) {
-    val likeIcon = if (isLike.value) {
+    val likeIcon = if (isLike) {
         R.drawable.heart_fill
     } else {
         R.drawable.heart
     }
 
-    val tintColor = if (isLike.value) {
+    val tintColor = if (isLike) {
         team.getPointColor()
     } else {
         MoyaColor.white
@@ -174,7 +170,7 @@ fun MusicNavigationBar(
                 .size(26.dp),
             onClick = {
                 //TODO: 데이터 추가
-                onClickHeartButton(isLike.value)
+                onClickHeartButton(isLike)
             }) {
             Icon(
                 painterResource(id = likeIcon),

--- a/app/src/main/java/com/soi/moya/ui/music_player/MusicPlayerScreen.kt
+++ b/app/src/main/java/com/soi/moya/ui/music_player/MusicPlayerScreen.kt
@@ -53,24 +53,8 @@ fun MusicPlayerScreen(
     navController: NavHostController,
     songId: String?
 ) {
-
     val currentPosition by rememberUpdatedState(newValue = viewModel.currentPosition.value)
     val duration = viewModel.getDuration()
-
-    val music = Music(
-        title = "Test title",
-        info = "test team name",
-        lyrics = "나는 행복합니다\n나는 행복합니다\n나는 행복합니다\n이글스라 행복합니다\n\n나는 행복합니다\n나는 행복합니다\n나는 행복합니다" +
-                "나는 행복합니다\n" +
-                "나는 행복합니다\n" +
-                "이글스라 행복합니다\n" +
-                "\n" +
-                "나는 행복합니다\n" +
-                "나는 행복합니다\n" +
-                "나는 행복합니다\n" +
-                "한화라서 행복합니다\n" +
-                "나는 행복합니다\n"
-    )
 
     val progress = remember { mutableFloatStateOf(0f) }
     val isLike = rememberSaveable { mutableStateOf( true ) }
@@ -82,7 +66,7 @@ fun MusicPlayerScreen(
             .padding(20.dp)
     ) {
         MusicNavigationBar(
-            music = music,
+            music = viewModel.music,
             isLike = isLike,
             onClickBackButton = {
                 viewModel.popBackStack(navController = navController)
@@ -94,7 +78,7 @@ fun MusicPlayerScreen(
         )
 
         MusicLylicView(
-            music = music,
+            music = viewModel.music,
             modifier = Modifier.weight(1f)
         )
 
@@ -213,12 +197,12 @@ fun MusicLylicView(
             .padding(vertical = 20.dp)
     ) {
         Text(
-            text = music.lyrics,
+            text = music.lyrics.replace("\\n", "\n"),
             modifier = Modifier
                 .fillMaxSize()
                 .verticalScroll(scrollState),
             style = getTextStyle(style = MoyaFont.CustomHeadlineBold),
-            color = MoyaColor.white
+            color = MoyaColor.white.copy(0.8f)
         )
 
         GradientBox(

--- a/app/src/main/java/com/soi/moya/ui/music_player/MusicPlayerScreen.kt
+++ b/app/src/main/java/com/soi/moya/ui/music_player/MusicPlayerScreen.kt
@@ -42,6 +42,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import com.soi.moya.R
 import com.soi.moya.models.Music
+import com.soi.moya.models.Team
 import com.soi.moya.ui.theme.MoyaColor
 import com.soi.moya.ui.theme.MoyaFont
 import com.soi.moya.ui.theme.getTextStyle
@@ -50,8 +51,7 @@ import com.soi.moya.ui.theme.getTextStyle
 @Composable
 fun MusicPlayerScreen(
     viewModel: MusicPlayerViewModel = viewModel(factory = MusicPlayerViewModel.Factory),
-    navController: NavHostController,
-    songId: String?
+    navController: NavHostController
 ) {
     val currentPosition by rememberUpdatedState(newValue = viewModel.currentPosition.value)
     val duration = viewModel.getDuration()
@@ -61,12 +61,13 @@ fun MusicPlayerScreen(
 
     Column(
         modifier = Modifier
-            .background(MoyaColor.doosanSub)
+            .background(viewModel.team.getSubColor())
             .fillMaxSize()
             .padding(20.dp)
     ) {
         MusicNavigationBar(
             music = viewModel.music,
+            team = viewModel.team,
             isLike = isLike,
             onClickBackButton = {
                 viewModel.popBackStack(navController = navController)
@@ -79,6 +80,7 @@ fun MusicPlayerScreen(
 
         MusicLylicView(
             music = viewModel.music,
+            team = viewModel.team,
             modifier = Modifier.weight(1f)
         )
 
@@ -103,6 +105,7 @@ fun MusicPlayerScreen(
 @Composable
 fun MusicNavigationBar(
     music: Music,
+    team: Team,
     isLike: MutableState<Boolean>,
     onClickBackButton: () -> Unit,
     onClickHeartButton: (Boolean) -> Unit
@@ -114,7 +117,7 @@ fun MusicNavigationBar(
     }
 
     val tintColor = if (isLike.value) {
-        MoyaColor.doosanPoint
+        team.getPointColor()
     } else {
         MoyaColor.white
     }
@@ -143,7 +146,7 @@ fun MusicNavigationBar(
                 .size(52.dp)
                 .aspectRatio(1f)
                 .clip(RoundedCornerShape(10.dp)),
-            painter = painterResource(id = R.drawable.album_doosan),
+            painter = painterResource(id = if (music.type) team.getPlayerAlbumImageResourceId() else team.getTeamAlbumImageResourceId()),
             contentDescription = null,
         )
 
@@ -185,7 +188,8 @@ fun MusicNavigationBar(
 @Composable
 fun MusicLylicView(
     modifier: Modifier,
-    music: Music
+    music: Music,
+    team: Team
 ) {
     val scrollState = rememberScrollState()
     val gradientTopColor = scrollState.value > 10
@@ -210,8 +214,8 @@ fun MusicLylicView(
                 .align(Alignment.TopCenter),
             isVisible = gradientTopColor,
             gradientColors = listOf(
-                MoyaColor.doosanSub,
-                MoyaColor.doosanSub.copy(0.3f)
+                team.getSubColor(),
+                team.getSubColor().copy(0.3f)
             )
         )
 
@@ -220,8 +224,8 @@ fun MusicLylicView(
                 .align(Alignment.BottomCenter),
             isVisible = gradientBottomColor,
             gradientColors = listOf(
-                MoyaColor.doosanSub.copy(0.3f),
-                MoyaColor.doosanSub
+                team.getSubColor().copy(0.3f),
+                team.getSubColor()
             )
         )
     }
@@ -272,8 +276,8 @@ fun MusicPlayerSlider(
             modifier = Modifier
                 .fillMaxWidth(),
             colors = SliderDefaults.colors(
-                thumbColor = MoyaColor.doosanPoint,
-                activeTrackColor = MoyaColor.doosanPoint,
+                thumbColor = viewModel.team.getPointColor(),
+                activeTrackColor = viewModel.team.getPointColor(),
                 inactiveTrackColor = MoyaColor.gray,
             ),
         )

--- a/app/src/main/java/com/soi/moya/ui/music_player/MusicPlayerViewModel.kt
+++ b/app/src/main/java/com/soi/moya/ui/music_player/MusicPlayerViewModel.kt
@@ -16,6 +16,7 @@ import androidx.lifecycle.viewmodel.CreationExtras
 import androidx.navigation.NavHostController
 import com.soi.moya.data.MusicManager
 import com.soi.moya.models.Music
+import com.soi.moya.models.Team
 import com.soi.moya.repository.MusicPlayerManager
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -34,8 +35,11 @@ class MusicPlayerViewModel(
     application: Application,
     savedStateHandle: SavedStateHandle
 ): AndroidViewModel(application) {
-    private val songId: String =  checkNotNull(savedStateHandle["songId"])
-    val music: Music = MusicManager.getInstance().getMusicById(songId)
+    private val _songId: String =  checkNotNull(savedStateHandle["songId"])
+    val music: Music = MusicManager.getInstance().getMusicById(_songId)
+
+    private val _teamName: String = checkNotNull(savedStateHandle["team"])
+    val team: Team = Team.valueOf(_teamName)
 
     private val _musicPlayerManager = mutableStateOf(MusicPlayerManager(application))
 

--- a/app/src/main/java/com/soi/moya/ui/music_storage/MusicStorageScreen.kt
+++ b/app/src/main/java/com/soi/moya/ui/music_storage/MusicStorageScreen.kt
@@ -195,6 +195,7 @@ fun ItemView(
 
     MusicListItem(
         music = music.toMusic(),
+        team = Team.valueOf(music.team),
         buttonImageResourceId = R.drawable.ellipse,
         onClickCell = {
             navController.navigate("MUSIC_PLAYER/123")

--- a/app/src/main/java/com/soi/moya/ui/music_storage/MusicStorageScreen.kt
+++ b/app/src/main/java/com/soi/moya/ui/music_storage/MusicStorageScreen.kt
@@ -198,7 +198,7 @@ fun ItemView(
         team = Team.valueOf(music.team),
         buttonImageResourceId = R.drawable.ellipse,
         onClickCell = {
-            navController.navigate("MUSIC_PLAYER/123")
+            navController.navigate("MUSIC_PLAYER/${music.team}/${music.id}")
         },
         onClickExtraButton = {
             showBottomSheet = true

--- a/app/src/main/java/com/soi/moya/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/soi/moya/ui/search/SearchScreen.kt
@@ -49,8 +49,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import com.soi.moya.R
-import com.soi.moya.models.Music
-import com.soi.moya.models.Team
+import com.soi.moya.models.MusicInfo
 import com.soi.moya.ui.AppViewModelProvider
 import com.soi.moya.ui.Utility
 import com.soi.moya.ui.WindowSize
@@ -84,12 +83,11 @@ fun SearchScreen(
 }
 
 @Composable
-fun ResultView(result: List<Music>, navController: NavHostController) {
+fun ResultView(result: List<MusicInfo>, navController: NavHostController) {
     LazyColumn {
         items(result) { music ->
-            listItem(music = music, team = Team.nc) {
-                //TODO: navigation 연결
-                navController.navigate("MUSIC_PLAYER/${music.id}")
+            listItem(music = music) {
+                navController.navigate("MUSIC_PLAYER/${music.team.name}/${music.id}")
             }
         }
     }
@@ -244,7 +242,7 @@ fun SearchBar(viewModel: SearchViewModel) {
 }
 
 @Composable
-fun listItem(music: Music, team: Team, onClickEvent: () -> Unit) {
+fun listItem(music: MusicInfo, onClickEvent: () -> Unit) {
     Row(
         modifier = Modifier
             .background(MoyaColor.white)
@@ -264,7 +262,7 @@ fun listItem(music: Music, team: Team, onClickEvent: () -> Unit) {
                         .size(40.dp)
                         .aspectRatio(1f)
                         .clip(RoundedCornerShape(8.dp)),
-                    painter = painterResource(id = team.getTeamAlbumImageResourceId()),
+                    painter = painterResource(id = music.team.getTeamAlbumImageResourceId()),
                     contentDescription = null,
                 )
                 Column(
@@ -277,7 +275,7 @@ fun listItem(music: Music, team: Team, onClickEvent: () -> Unit) {
                     )
                     Spacer(modifier = Modifier.size(6.dp))
                     Text(
-                        text = team.getKrTeamName(),
+                        text = music.team.getKrTeamName(),
                         color = MoyaColor.darkGray,
                         style = getTextStyle(style = MoyaFont.CustomCaptionMedium)
                     )

--- a/app/src/main/java/com/soi/moya/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/com/soi/moya/ui/search/SearchViewModel.kt
@@ -4,7 +4,7 @@ import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.soi.moya.data.MusicManager
-import com.soi.moya.models.Music
+import com.soi.moya.models.MusicInfo
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
@@ -17,10 +17,10 @@ class SearchViewModel(application: Application) : AndroidViewModel(application) 
     private val _searchText = MutableStateFlow("")
     val searchText: StateFlow<String> = _searchText
 
-    private val _musicFlow = MutableStateFlow<List<Music>>(emptyList())
+    private val _musicFlow = MutableStateFlow<List<MusicInfo>>(emptyList())
 
-    private val _searchResult = MutableStateFlow<List<Music>>(emptyList())
-    val searchResult: StateFlow<List<Music>> = _searchResult
+    private val _searchResult = MutableStateFlow<List<MusicInfo>>(emptyList())
+    val searchResult: StateFlow<List<MusicInfo>> = _searchResult
 
 
     init {
@@ -30,7 +30,7 @@ class SearchViewModel(application: Application) : AndroidViewModel(application) 
 
     private fun observeMusicList() {
         viewModelScope.launch {
-            _musicManager.getAllMusics().observeForever { musics ->
+            _musicManager.getAllMusicInfo().observeForever { musics ->
                 _musicFlow.value = musics
             }
         }


### PR DESCRIPTION
### 연관 이슈
- closes #56 

### 변경 사항
- build.gradle 파일에서 중복되는 의존성을 삭제하고 알파벳 순서대로 정리했습니다.
- MusicInfo (id, title, lyrics, info, type, url, **team**)  객체 선언 -> 검색 화면에서 사용
- MusicManager에서 id값으로 객체 찾는 함수와 MusicInfo(Music에서 팀정보를 포함한 객체)형태로 반환하는 함수를 추가했습니다.
- 음악 재생 화면의 경로를 "MUSIC_PLAYER/{songId}" -> "MUSIC_PLAYER/{team}/{songId}" 으로 변경하여 팀 정보를 포함하도록 했습니다.
- 메인리스트의 이미지를 팀 정보와 연결했습니다. (selectedTeam 정보와 연결)
- 음악 재생 화면의 색상 및 이미지를 팀 정보와 연결했습니다. (navigate로 전달받은 팀 정보와 연결)
- 곡 선택 시 최초 재생일 경우 다운로드 후 다운로드된 음악을 재생하도록 했습니다
- 저장 형식은 "${music.id}-${music.title}.mp3" 으로 팀별로 동일한 제목을 가지는 음악의 경우가 존재하여 id값으로 구별할 수 있도록 했습니다.

### Previews

- 메인화면

[Screen_recording_20240215_194132.webm](https://github.com/Gwamegis/Moya-Android/assets/41153398/49697fe6-48be-4c46-b477-8d5175f1fa70)

- 검색화면

[Screen_recording_20240215_194229.webm](https://github.com/Gwamegis/Moya-Android/assets/41153398/2a74a5e0-5dec-4582-91b4-ef303b7b80f6)


