### PR TITLE
#71 - [Fix] 텍스트 고정 사이즈로 변경

### DIFF
--- a/app/src/main/java/com/soi/moya/ui/Utility.kt
+++ b/app/src/main/java/com/soi/moya/ui/Utility.kt
@@ -1,9 +1,6 @@
 package com.soi.moya.ui
 
 import android.content.Context
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.unit.Dp
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -40,8 +37,4 @@ object Utility {
         return dateFormat.format(Date())
     }
 
-    @Composable
-    fun dpToSp(dp: Dp) = with(LocalDensity.current) {
-        dp.toSp()
-    }
 }

--- a/app/src/main/java/com/soi/moya/ui/Utility.kt
+++ b/app/src/main/java/com/soi/moya/ui/Utility.kt
@@ -1,6 +1,9 @@
 package com.soi.moya.ui
 
 import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -35,5 +38,10 @@ object Utility {
     fun getCurrentTimeString(): String {
         val dateFormat = SimpleDateFormat("yyyyMMddHHmmss", Locale.getDefault())
         return dateFormat.format(Date())
+    }
+
+    @Composable
+    fun dpToSp(dp: Dp) = with(LocalDensity.current) {
+        dp.toSp()
     }
 }

--- a/app/src/main/java/com/soi/moya/ui/theme/MoyaFont.kt
+++ b/app/src/main/java/com/soi/moya/ui/theme/MoyaFont.kt
@@ -1,14 +1,15 @@
 package com.soi.moya.ui.theme
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.soi.moya.R
-import com.soi.moya.ui.Utility.dpToSp
 
 private val pretendard = FontFamily(
     Font(R.font.pretendard_medium, FontWeight.Medium, FontStyle.Normal),
@@ -99,4 +100,9 @@ fun getTextStyle(style: MoyaFont): TextStyle {
             )
         }
     }
+}
+
+@Composable
+private fun dpToSp(dp: Dp) = with(LocalDensity.current) {
+    dp.toSp()
 }

--- a/app/src/main/java/com/soi/moya/ui/theme/MoyaFont.kt
+++ b/app/src/main/java/com/soi/moya/ui/theme/MoyaFont.kt
@@ -6,8 +6,9 @@ import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.sp
+import androidx.compose.ui.unit.dp
 import com.soi.moya.R
+import com.soi.moya.ui.Utility.dpToSp
 
 private val pretendard = FontFamily(
     Font(R.font.pretendard_medium, FontWeight.Medium, FontStyle.Normal),
@@ -36,65 +37,65 @@ fun getTextStyle(style: MoyaFont): TextStyle {
         MoyaFont.CustomTitleBold -> {
             baseTextStyle.copy(
                 fontWeight = FontWeight.Bold,
-                fontSize = 20.sp,
-                lineHeight = 20.sp
+                fontSize = dpToSp(20.dp),
+                lineHeight = dpToSp(20.dp)
             )
         }
         MoyaFont.CustomTitleMedium -> {
             baseTextStyle.copy(
                 fontWeight = FontWeight.Medium,
-                fontSize = 20.sp,
-                lineHeight = 20.sp
+                fontSize = dpToSp(20.dp),
+                lineHeight = dpToSp(20.dp)
             )
         }
         MoyaFont.CustomBodyBold -> {
             baseTextStyle.copy(
                 fontWeight = FontWeight.Bold,
-                fontSize = 16.sp,
-                lineHeight = 16.sp
+                fontSize = dpToSp(16.dp),
+                lineHeight = dpToSp(16.dp)
             )
         }
         MoyaFont.CustomBodyMedium -> {
             baseTextStyle.copy(
                 fontWeight = FontWeight.Medium,
-                fontSize = 16.sp,
-                lineHeight = 21.sp
+                fontSize = dpToSp(16.dp),
+                lineHeight = dpToSp(21.dp)
             )
         }
         MoyaFont.CustomCaptionBold -> {
             baseTextStyle.copy(
                 fontWeight = FontWeight.Bold,
-                fontSize = 12.sp,
-                lineHeight = 12.sp
+                fontSize = dpToSp(12.dp),
+                lineHeight = dpToSp(12.dp)
             )
         }
         MoyaFont.CustomCaptionMedium -> {
             baseTextStyle.copy(
                 fontWeight = FontWeight.Medium,
-                fontSize = 10.sp,
-                lineHeight = 10.sp
+                fontSize = dpToSp(10.dp),
+                lineHeight = dpToSp(10.dp)
             )
         }
         MoyaFont.CustomHeadline -> {
             baseTextStyle.copy(
                 fontWeight = FontWeight.Medium,
-                fontSize = 26.sp,
-                lineHeight = 50.sp
+                fontSize = dpToSp(26.dp),
+                lineHeight = dpToSp(50.dp)
             )
         }
         MoyaFont.CustomHeadlineBold -> {
             baseTextStyle.copy(
                 fontWeight = FontWeight.Bold,
-                fontSize = 26.sp,
-                lineHeight = 45.sp
+                fontSize = dpToSp(26.dp),
+                lineHeight = dpToSp(45.dp)
             )
         }
 
         MoyaFont.CustomStorageHeaderTitle -> {
             baseTextStyle.copy(
                 fontWeight = FontWeight.Bold,
-                fontSize = 40.sp,
-                lineHeight = 40.sp
+                fontSize = dpToSp(40.dp),
+                lineHeight = dpToSp(40.dp)
             )
         }
     }


### PR DESCRIPTION
### 스크린샷

https://github.com/Gwamegis/Moya-Android/assets/68676844/80426c1f-0073-448f-a811-c30a319d0890

### 공유사항
- 컴포즈 자체에서 Text Size의 경우 dp를 제공하고 있지 않아 하단 정보 참고하여 작업했습니다.
- 실기기 테스트 후 문제가 해결되지 않는다면 다른 방법 찾아 공유드리겠습니다!
- Utility 클래스 내부에 존재하는게 맞는 것 같기도 하고.. Font 클래스 내부에서만 사용하기 때문에 굳이 Utility에 넣을 필요가 없는 것 같기도 하고 .. 지민님 의견은 어떠신가요! 저는 적으면서 Font 정의하는 곳에 넣는게 더 좋을 것 같긴 하네요! 의견 들어보고 결정하겠습니다!

### 참고 사이트 
- [stack overflow](https://stackoverflow.com/questions/67918698/why-is-there-only-sp-in-fontsize-of-text-composable-and-not-dp-in-jetp)
