### PR TITLE
#72 [Fix] - 음악 중복 재생 이슈

### DIFF
--- a/app/src/main/java/com/soi/moya/repository/MusicPlayerManager.kt
+++ b/app/src/main/java/com/soi/moya/repository/MusicPlayerManager.kt
@@ -1,13 +1,22 @@
 package com.soi.moya.repository
 
-import android.app.Application
 import android.media.AudioAttributes
 import android.media.MediaPlayer
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import java.io.IOException
 
-class MusicPlayerManager(application: Application) {
+class MusicPlayerManager private constructor() {
+    companion object {
+        @Volatile
+        private var instance: MusicPlayerManager? = null
+
+        fun getInstance() =
+            instance ?: synchronized(this) {
+                instance ?: MusicPlayerManager().also { instance = it }
+            }
+    }
+
     private val _isPlaying = MutableStateFlow(false)
     val isPlaying: StateFlow<Boolean> = _isPlaying
 

--- a/app/src/main/java/com/soi/moya/ui/music_player/MusicPlayerScreen.kt
+++ b/app/src/main/java/com/soi/moya/ui/music_player/MusicPlayerScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavHostController
 import com.soi.moya.R
 import com.soi.moya.models.Music
@@ -56,6 +57,7 @@ fun MusicPlayerScreen(
 
     val progress = remember { mutableFloatStateOf(0f) }
     val isLike by viewModel.isLike.collectAsState()
+    var previousDestination: NavBackStackEntry? = null
 
     Column(
         modifier = Modifier
@@ -95,6 +97,14 @@ fun MusicPlayerScreen(
                 viewModel.togglePlayPause()
             }
         )
+    }
+
+    navController.addOnDestinationChangedListener { _, _, _->
+        val currentDestination = navController.previousBackStackEntry
+        if (currentDestination == previousDestination) {
+            viewModel.stopMusic()
+        }
+        previousDestination = navController.currentBackStackEntry
     }
 }
 

--- a/app/src/main/java/com/soi/moya/ui/music_player/MusicPlayerViewModel.kt
+++ b/app/src/main/java/com/soi/moya/ui/music_player/MusicPlayerViewModel.kt
@@ -46,7 +46,7 @@ class MusicPlayerViewModel(
     private val _teamName: String = checkNotNull(savedStateHandle["team"])
     val team: Team = Team.valueOf(_teamName)
 
-    private val _musicPlayerManager = mutableStateOf(MusicPlayerManager(application))
+    private val _musicPlayerManager = mutableStateOf(MusicPlayerManager.getInstance())
 
     private val _isPlaying = MutableStateFlow(false)
     val isPlaying: StateFlow<Boolean> = _isPlaying
@@ -125,7 +125,6 @@ class MusicPlayerViewModel(
     }
 
     fun popBackStack(navController: NavHostController) {
-        _musicPlayerManager.value.stop()
         navController.popBackStack()
     }
 

--- a/app/src/main/java/com/soi/moya/ui/music_player/MusicPlayerViewModel.kt
+++ b/app/src/main/java/com/soi/moya/ui/music_player/MusicPlayerViewModel.kt
@@ -125,7 +125,12 @@ class MusicPlayerViewModel(
     }
 
     fun popBackStack(navController: NavHostController) {
+        stopMusic()
         navController.popBackStack()
+    }
+
+    fun stopMusic() {
+        _musicPlayerManager.value.stop()
     }
 
     //음악 다운로드


### PR DESCRIPTION
### 이슈 원인
- Music Manager가 싱글톤으로 선언되어있지 않음.
- 네비게이션 상단 백버튼 클릭 시 정지하는 로직이 존재하나, 안드로이드 기기에 있는 Backbutton에 대한 코드 누락되어있었음.

### 작업 사항
- 응원가를 들으면서 모야 앱을 탐색하는 것에 대한 니즈는 많지 않았습니다. (*구글폼 기준)
  -> 기존 버전과 다르게 가사 뷰에서 뒤로 넘어갔을 때, 음악 재생을 멈추도록 수정했습니다.

### 해결 방법
- `addOnDestinationChangedListener`를 활용했습니다.
  - 음악 리스트 -> 음악 재생 화면 / 음악 재생 화면 -> 음악 리스트로 변경되는 리스너를 통해서 backbutton 작동을 감지하였습니다.
  - 이에 기존 상단 백버튼에 존재했던 음악 정지 로직을 분리하여 작성했습니다!

### 공유사항
- 음악 재생의 경우, 화면 녹화로 공유하기 어려워 스크린샷은 첨부하지 못했습니다