### PR TITLE
#70 [Fix] - 필수 업데이트에서 배경을 탭 하면, 앱을 사용할 수 있는 문제 해결

### DIFF
--- a/app/src/main/java/com/soi/moya/ui/bottom_nav/BottomNavScreen.kt
+++ b/app/src/main/java/com/soi/moya/ui/bottom_nav/BottomNavScreen.kt
@@ -51,6 +51,7 @@ import com.soi.moya.ui.select_team.SelectTeamScreen
 import com.soi.moya.ui.theme.MoyaColor
 import com.soi.moya.ui.theme.MoyaTheme
 import kotlinx.coroutines.launch
+import kotlin.system.exitProcess
 
 @Composable
 fun BottomNavScreen() {
@@ -142,7 +143,7 @@ private fun NoticeBottomSheet(
             scope.launch {
                 val shouldTerminateApp = viewModel.checkRequiredUpdate()
                 if (shouldTerminateApp) {
-                    activity?.finish()
+                    exitProcess(0)
                 }
                 newFeatureSheetState.hide()
             }

--- a/app/src/main/java/com/soi/moya/ui/notice/new_feature/NewFeatureNoticeScreen.kt
+++ b/app/src/main/java/com/soi/moya/ui/notice/new_feature/NewFeatureNoticeScreen.kt
@@ -4,6 +4,7 @@ import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -16,8 +17,10 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.ModalBottomSheetLayout
 import androidx.compose.material.ModalBottomSheetState
+import androidx.compose.material.ModalBottomSheetValue
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -45,6 +48,12 @@ fun NewFeatureNoticeScreen(
 ) {
     val scope = rememberCoroutineScope()
 
+    LaunchedEffect(sheetState.currentValue) {
+        if (sheetState.currentValue == ModalBottomSheetValue.Hidden) {
+            onDismissRequest()
+        }
+    }
+
     ModalBottomSheetLayout(
         sheetState = sheetState,
         sheetContent = {
@@ -55,7 +64,6 @@ fun NewFeatureNoticeScreen(
                         scope.launch {
                             sheetState.hide()
                         }
-                        onDismissRequest()
                     }
                 )
             }

--- a/app/src/main/java/com/soi/moya/ui/notice/new_feature/NewFeatureNoticeScreen.kt
+++ b/app/src/main/java/com/soi/moya/ui/notice/new_feature/NewFeatureNoticeScreen.kt
@@ -54,6 +54,8 @@ fun NewFeatureNoticeScreen(
         }
     }
 
+    BackHandler { }
+
     ModalBottomSheetLayout(
         sheetState = sheetState,
         sheetContent = {


### PR DESCRIPTION
### 변경사항
1. 앱 종료 방식 변경
 - `activity?.finish()` ->  `exitProcess(0)`
 - activity 종료하는 경우, 다시 앱이 켜졌을 때, 비정상적인 작동을 하는 현상이 발생하여 프로세스를 종료시키도록 변경하였습니다.

2. 뒤로가기 버튼 비활성화
 - 위와 같은 현상이 발생하여 "Feature" 관련 bottom sheet 에서는 뒤로 가기 버튼을 비활성화하도록 변경하였습니다.

### 변경사항 설명 스크린샷

https://github.com/Gwamegis/Moya-Android/assets/68676844/8177b35b-8bee-4361-8a20-11097c43aeae

### 필수 업데이트 동작 스크린샷

https://github.com/Gwamegis/Moya-Android/assets/68676844/77dc895f-ab78-482f-936f-97cda1db3b76

