### PR TITLE
#QA - 4, 6, 7, 9, 10, 11 

### DIFF
--- a/app/src/main/java/com/soi/moya/base/BaseComposeActivity.kt
+++ b/app/src/main/java/com/soi/moya/base/BaseComposeActivity.kt
@@ -1,9 +1,14 @@
 package com.soi.moya.base
 
+import android.graphics.Color
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.toArgb
+import com.soi.moya.ui.theme.MoyaColor
 
 abstract class BaseComposeActivity: ComponentActivity() {
 
@@ -12,6 +17,17 @@ abstract class BaseComposeActivity: ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        enableEdgeToEdge(
+            statusBarStyle = SystemBarStyle.light(
+                scrim = Color.TRANSPARENT,
+                darkScrim = Color.TRANSPARENT
+            ),
+            navigationBarStyle = SystemBarStyle.light(
+                scrim = MoyaColor.tabBarGray.toArgb(),
+                darkScrim = MoyaColor.tabBarGray.toArgb()
+            )
+        )
         setContent {
             Content()
         }

--- a/app/src/main/java/com/soi/moya/base/BaseComposeActivity.kt
+++ b/app/src/main/java/com/soi/moya/base/BaseComposeActivity.kt
@@ -24,8 +24,8 @@ abstract class BaseComposeActivity: ComponentActivity() {
                 darkScrim = Color.TRANSPARENT
             ),
             navigationBarStyle = SystemBarStyle.light(
-                scrim = MoyaColor.tabBarGray.toArgb(),
-                darkScrim = MoyaColor.tabBarGray.toArgb()
+                scrim = Color.TRANSPARENT,
+                darkScrim = Color.TRANSPARENT
             )
         )
         setContent {

--- a/app/src/main/java/com/soi/moya/repository/FirebaseRepository.kt
+++ b/app/src/main/java/com/soi/moya/repository/FirebaseRepository.kt
@@ -9,6 +9,7 @@ class FirebaseRepository<T>(
 ) {
     fun getData(collection: String, result: (UiState<List<T>>) -> Unit) {
         database.collection(collection)
+            .orderBy("title")
             .get()
             .addOnSuccessListener {
                 val data = it.toObjects(clazz)

--- a/app/src/main/java/com/soi/moya/ui/bottom_nav/BottomNavScreen.kt
+++ b/app/src/main/java/com/soi/moya/ui/bottom_nav/BottomNavScreen.kt
@@ -2,6 +2,7 @@ package com.soi.moya.ui.bottom_nav
 
 import android.app.Activity
 import androidx.annotation.StringRes
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
@@ -22,6 +23,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.remember
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -168,7 +170,9 @@ fun BottomNav(navController: NavHostController) {
 
     BottomNavigation(
         backgroundColor = color.tabBarGray,
-        modifier = Modifier.navigationBarsPadding(),
+        modifier = Modifier
+            .background(color = color.tabBarGray)
+            .navigationBarsPadding(),
         elevation = 0.dp
     ) {
         val navBackStackEntry by navController.currentBackStackEntryAsState()

--- a/app/src/main/java/com/soi/moya/ui/bottom_nav/BottomNavScreen.kt
+++ b/app/src/main/java/com/soi/moya/ui/bottom_nav/BottomNavScreen.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.BottomNavigation
@@ -167,6 +168,8 @@ fun BottomNav(navController: NavHostController) {
 
     BottomNavigation(
         backgroundColor = color.tabBarGray,
+        modifier = Modifier.navigationBarsPadding(),
+        elevation = 0.dp
     ) {
         val navBackStackEntry by navController.currentBackStackEntryAsState()
         val currentRoute = navBackStackEntry?.destination?.route
@@ -192,7 +195,8 @@ fun BottomNav(navController: NavHostController) {
                             .height(26.dp)
                     )
                 },
-                modifier = Modifier.padding(horizontal = 8.dp),
+                modifier = Modifier
+                    .padding(horizontal = 8.dp),
                 label = {
                     Text(
                         stringResource(id = item.labelID),

--- a/app/src/main/java/com/soi/moya/ui/component/MusicListItem.kt
+++ b/app/src/main/java/com/soi/moya/ui/component/MusicListItem.kt
@@ -79,11 +79,14 @@ fun MusicInfoView(music: Music, team: Team) {
             music.title, color = MoyaColor.black,
             style = getTextStyle(style = MoyaFont.CustomBodyMedium)
         )
-        Spacer(modifier = Modifier.size(6.dp))
-        Text(
-            music.info, color = MoyaColor.darkGray,
-            style = getTextStyle(style = MoyaFont.CustomCaptionMedium)
-        )
+
+        if (music.info.isNotEmpty()) {
+            Spacer(modifier = Modifier.size(6.dp))
+            Text(
+                music.info, color = MoyaColor.darkGray,
+                style = getTextStyle(style = MoyaFont.CustomCaptionMedium)
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/soi/moya/ui/listItem_menu/ListItemMenuScreen.kt
+++ b/app/src/main/java/com/soi/moya/ui/listItem_menu/ListItemMenuScreen.kt
@@ -56,7 +56,7 @@ fun ListItemMenuScreen(
         MenuItem(
             doesExist.value,
             favorite = {
-                viewModel.saveItem(music = music, team = Team.doosan)
+                viewModel.saveItem(music = music, team = team)
                 onClick()
             },
             favoriteCancle = {

--- a/app/src/main/java/com/soi/moya/ui/music_list/MusicListScreen.kt
+++ b/app/src/main/java/com/soi/moya/ui/music_list/MusicListScreen.kt
@@ -251,8 +251,7 @@ fun MusicListItemView(music: Music, team: Team, navController: NavHostController
             Box(modifier = Modifier.navigationBarsPadding()) {
                 ListItemMenuScreen(
                     music = music,
-                    //TODO: 팀정보 연결
-                    team = Team.doosan,
+                    team = team,
                     onClick = {
                         scope.launch { sheetState.hide() }.invokeOnCompletion {
                             if (!sheetState.isVisible) {

--- a/app/src/main/java/com/soi/moya/ui/music_player/MusicPlayerScreen.kt
+++ b/app/src/main/java/com/soi/moya/ui/music_player/MusicPlayerScreen.kt
@@ -159,7 +159,8 @@ fun MusicNavigationBar(
         Column(
             modifier = Modifier
                 .padding(vertical = 6.dp)
-                .weight(1f)
+                .weight(1f),
+            verticalArrangement = Arrangement.spacedBy(6.dp)
         ) {
 
             Text(
@@ -204,7 +205,7 @@ fun MusicLylicView(
     Box(
         modifier = modifier
             .fillMaxWidth()
-            .padding(vertical = 20.dp)
+            .padding(vertical = 20.dp, horizontal = 20.dp)
     ) {
         Text(
             text = music.lyrics.replace("\\n", "\n"),
@@ -291,15 +292,17 @@ fun MusicPlayerSlider(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 20.dp),
+                .padding(horizontal = 8.dp),
             horizontalArrangement = Arrangement.SpaceBetween
         ) {
             Text(
                 text = viewModel.formatTime(currentPosition),
+                style = getTextStyle(style = MoyaFont.CustomCaptionMedium),
                 color = MoyaColor.white
             )
             Text(
                 text = viewModel.formatTime(duration),
+                style = getTextStyle(style = MoyaFont.CustomCaptionMedium),
                 color = MoyaColor.white
             )
         }
@@ -318,7 +321,7 @@ fun MusicPlayerBottomButtonView(
     ) {
         Image(
             modifier = Modifier
-                .size(50.dp)
+                .size(60.dp)
                 .aspectRatio(1f)
                 .clip(RoundedCornerShape(25.dp))
                 .clickable { onClickPlayButton() },

--- a/app/src/main/java/com/soi/moya/ui/music_player/MusicPlayerScreen.kt
+++ b/app/src/main/java/com/soi/moya/ui/music_player/MusicPlayerScreen.kt
@@ -1,6 +1,8 @@
 package com.soi.moya.ui.music_player
 
 import android.annotation.SuppressLint
+import android.util.Log
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -60,6 +62,10 @@ fun MusicPlayerScreen(
     val isLike by viewModel.isLike.collectAsState()
     var previousDestination: NavBackStackEntry? = null
 
+    BackHandler {
+        viewModel.popBackStack(navController)
+    }
+
     Column(
         modifier = Modifier
             .background(viewModel.team.getSubColor())
@@ -98,14 +104,6 @@ fun MusicPlayerScreen(
                 viewModel.togglePlayPause()
             }
         )
-    }
-
-    navController.addOnDestinationChangedListener { _, _, _->
-        val currentDestination = navController.previousBackStackEntry
-        if (currentDestination == previousDestination) {
-            viewModel.stopMusic()
-        }
-        previousDestination = navController.currentBackStackEntry
     }
 }
 

--- a/app/src/main/java/com/soi/moya/ui/music_player/MusicPlayerScreen.kt
+++ b/app/src/main/java/com/soi/moya/ui/music_player/MusicPlayerScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
@@ -316,7 +317,8 @@ fun MusicPlayerBottomButtonView(
 ) {
     Box(
         modifier = Modifier
-            .fillMaxWidth(),
+            .fillMaxWidth()
+            .navigationBarsPadding(),
         contentAlignment = Alignment.Center,
     ) {
         Image(

--- a/app/src/main/java/com/soi/moya/ui/music_storage/MusicStorageScreen.kt
+++ b/app/src/main/java/com/soi/moya/ui/music_storage/MusicStorageScreen.kt
@@ -218,8 +218,7 @@ fun ItemView(
             Box(modifier = Modifier.navigationBarsPadding()) {
                 ListItemMenuScreen(
                     music = music.toMusic(),
-                    //TODO: 팀정보 연결
-                    team = Team.doosan,
+                    team = Team.valueOf(music.team),
                     onClick = {
                         scope.launch { sheetState.hide() }.invokeOnCompletion {
                             if (!sheetState.isVisible) {

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -12,10 +12,7 @@
         <!-- Status bar color. -->
         <item name="android:windowLightStatusBar" tools:targetApi="m">true</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
-        <item name="android:navigationBarColor">@android:color/transparent</item>
-        <item name="android:enforceNavigationBarContrast" tools:targetApi="q">false</item>
-        <item name="android:enforceStatusBarContrast" tools:targetApi="q">false</item>
-        <item name="android:windowTranslucentStatus">true</item>
+        <item name="android:navigationBarColor">@color/tabBarGray</item>
         <!-- Customize your theme here. -->
     </style>
 </resources>


### PR DESCRIPTION
## 변경사항
- 음악 목록 더보기 창 팀 이미지 수정
- 음악 목록 가나다순 정렬
- 음악 목록 아이템 info 정보 없는 경우 정렬 수정
- 음악 재생 화면 디자인 수정
    - title - info 사이 간격 설정 (6.dp)
    - 가사 좌우 여백 추가 (20.dp)
    - 재생바 시간 텍스트 폰트 적용 (CustomCaptionMedium)
    - 재생버튼 크기 변경 (50.dp -> 60.dp)
- statusbar 색상 변경 (반투명 -> 투명)
- 음악 재생화면에서 뒤로가는 경우 음악 재생 종료
    - 기존 리스너로 뒤로가기 동작을 감지하는 경우 검색화면 -> 음악 재생 으로 접근한 경우 동작하지 않는 문제가 발생하여 음악 재생 화면에서 BackHandler적용으로 변경하여 해결했습니다.

### Preview
|더보기-메인|더보기-보관함|음악목록|재생화면|
|:---:|:---:|:---:|:---:|
|<img width="224" alt="스크린샷 2024-03-08 오후 9 44 52" src="https://github.com/Gwamegis/Moya-Android/assets/41153398/f1191e92-92c9-42d4-8984-0d81ea7c00ac">|<img width="225" alt="스크린샷 2024-03-08 오후 9 45 02" src="https://github.com/Gwamegis/Moya-Android/assets/41153398/724ac2b4-128e-467f-9b72-ed5c3c58b6c6">|<img width="226" alt="스크린샷 2024-03-08 오후 9 44 41" src="https://github.com/Gwamegis/Moya-Android/assets/41153398/8e901d75-8d01-4b04-bb98-ed204e945adc">|<img width="217" alt="스크린샷 2024-03-08 오후 9 58 52" src="https://github.com/Gwamegis/Moya-Android/assets/41153398/223e6f15-e188-43f5-ba97-98ce6cbb6a8a">|
